### PR TITLE
[Memory Leak] Removed all callbacks from the channel after leaving

### DIFF
--- a/Source/Channel.swift
+++ b/Source/Channel.swift
@@ -55,6 +55,7 @@ open class Channel {
         state = .Leaving
 
         return send(Socket.Event.Leave, payload: [:])?.receive("ok", callback: { response in
+	    self.callbacks.removeAll()
             self.state = .Closed
         })
     }


### PR DESCRIPTION
First off, great job with the library! 🎉 Its been really enjoyable to work with! 

I found another memory leak. Currently if you pass in an already predefined function that is part of a class:

```swift
private func joinChannel() {
     channel = ...
     channel?.on("new_msg",   callback: onNewMessageEvent)
     channel?.join()?
}

private func onNewMessageEvent(response: Response) {
       // New message
}
```

It will never deinit. So whenever we receive confirmation that we left the channel, I removed the callbacks from the dictionary variable since we no longer need them.

```swift
@discardableResult
open func leave() -> Push? {
      state = .Leaving

     return send(Socket.Event.Leave, payload: [:])?.receive("ok", callback: { response in
          self.callbacks.removeAll() // Fixes memory leak
          self.state = .Closed
     })
}
```

Thanks! 