### PR TITLE
[MemoryLeak] Presence callbacks now deallocated after leaving the channel

### DIFF
--- a/Source/Channel.swift
+++ b/Source/Channel.swift
@@ -56,6 +56,9 @@ open class Channel {
 
         return send(Socket.Event.Leave, payload: [:])?.receive("ok", callback: { response in
 	    self.callbacks.removeAll()
+	    self.presence.onJoin = nil
+            self.presence.onLeave = nil
+            self.presence.onStateChange = nil
             self.state = .Closed
         })
     }


### PR DESCRIPTION
Currently, if you do anything inside these methods that pertain to the class that it's in such as calling a delegate, calling another function, etc.. it will cause a retain cycle. Setting these to nil after leaving the channel breaks this retain cycle