### PR TITLE
Fix bug in `syncJoins` in Presence.swift

### DIFF
--- a/Source/Presence.swift
+++ b/Source/Presence.swift
@@ -95,7 +95,7 @@ public final class Presence {
         diff.forEach { id, entry in
             if let metas = entry["metas"] as? [Meta] {
                 if var existing = state[id] {
-                    existing += metas
+                    state[id] = existing + metas
                 }
                 else {
                     state[id] = metas


### PR DESCRIPTION
`state[id]` was not getting updated with the new `metas`, so if a single user joins with more than one client, the state is incorrect.